### PR TITLE
feat: add support for JavaScript const object format in palette import

### DIFF
--- a/palette-lab.html
+++ b/palette-lab.html
@@ -206,13 +206,20 @@
                 <input type="text" id="paletteNameInput" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary" placeholder="z.B. Meine Custom Palette">
             </div>
             <div class="mb-4">
-                <label for="jsonTextArea" class="block text-sm font-medium mb-2">JSON Daten:</label>
-                <textarea id="jsonTextArea" class="w-full h-64 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary font-mono text-sm" placeholder='Fügen Sie hier Ihr JSON ein, z.B.:
+                <label for="jsonTextArea" class="block text-sm font-medium mb-2">JSON oder JavaScript Daten:</label>
+                <textarea id="jsonTextArea" class="w-full h-64 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary font-mono text-sm" placeholder='Fügen Sie hier Ihre Daten ein. Unterstützte Formate:
+
+JSON:
 {
   "primary": "#667eea",
   "primaryLight": "#8b9cff",
-  "primaryDark": "#4f63d2",
-  "secondary": "#764ba2",
+  ...
+}
+
+JavaScript const:
+const colors = {
+  primary: "#1d4ed8",
+  primaryLight: "#3b82f6",
   ...
 }'></textarea>
             </div>

--- a/palette-lab.js
+++ b/palette-lab.js
@@ -146,7 +146,7 @@ class PaletteLab {
         }
 
         try {
-            const data = JSON.parse(jsonText);
+            const data = this.parseInput(jsonText);
             const palette = this.validatePalette(data);
             const uniqueName = this.generateUniqueName(name);
 
@@ -280,6 +280,41 @@ class PaletteLab {
             this.applyPalette(uniqueName);
         } catch (error) {
             this.showError('Fehler beim Erstellen', error.message);
+        }
+    }
+
+    parseInput(inputText) {
+        // Try to parse as regular JSON first
+        try {
+            return JSON.parse(inputText);
+        } catch (jsonError) {
+            // If JSON parsing fails, try to parse as JavaScript const object
+            try {
+                return this.parseJavaScriptObject(inputText);
+            } catch (jsError) {
+                // If both fail, throw a more helpful error
+                throw new Error('Ungültiges Format. Bitte verwenden Sie entweder JSON oder JavaScript const Syntax.\n\nJSON Fehler: ' + jsonError.message + '\nJavaScript Fehler: ' + jsError.message);
+            }
+        }
+    }
+
+    parseJavaScriptObject(inputText) {
+        let cleanedText = inputText.trim();
+
+        // Remove 'const' declaration and variable name
+        cleanedText = cleanedText.replace(/^const\s+\w+\s*=\s*/, '');
+        
+        // Remove trailing semicolon
+        cleanedText = cleanedText.replace(/;?\s*$/, '');
+
+        // Convert JavaScript object syntax to JSON
+        // Handle unquoted keys by wrapping them in quotes
+        cleanedText = cleanedText.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+
+        try {
+            return JSON.parse(cleanedText);
+        } catch (error) {
+            throw new Error('Ungültiges JavaScript Object Format: ' + error.message);
         }
     }
 


### PR DESCRIPTION
- Add parseInput() method to handle both JSON and JavaScript const syntax
- Add parseJavaScriptObject() method to convert JS const to JSON
- Update UI text to indicate support for both formats
- Support format: const colors = { primary: '#1d4ed8', ... }

Fixes #7