### PR TITLE
feat: Add hover sidebar with smooth transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,137 @@
             }
         }
     </script>
+    <style>
+        /* Sidebar Styles */
+        .sidebar-trigger {
+            position: fixed;
+            left: 0;
+            top: 0;
+            width: 8px;
+            height: 100vh;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            cursor: pointer;
+            z-index: 1001;
+            transition: width 0.3s cubic-bezier(.68,-0.55,.27,1.55);
+        }
+
+        .sidebar-trigger:hover {
+            width: 12px;
+        }
+
+        .sidebar {
+            position: fixed;
+            left: -240px;
+            top: 0;
+            width: 240px;
+            height: 100vh;
+            background: rgba(0, 26, 77, 0.95);
+            backdrop-filter: blur(20px);
+            border-right: 1px solid rgba(255, 255, 255, 0.1);
+            transition: left 0.3s cubic-bezier(.68,-0.55,.27,1.55);
+            z-index: 1000;
+        }
+
+        .sidebar-trigger:hover + .sidebar,
+        .sidebar:hover {
+            left: 0;
+        }
+
+        .sidebar-content {
+            padding: 2rem 1.5rem;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .sidebar-menu {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .sidebar-item {
+            display: flex;
+            align-items: center;
+            padding: 0.75rem 1rem;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            border-radius: 12px;
+            transition: all 0.3s ease;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .sidebar-item:hover {
+            color: white;
+            background: rgba(255, 255, 255, 0.15);
+            border-color: rgba(255, 255, 255, 0.2);
+            transform: translateX(4px);
+        }
+
+        .sidebar-icon {
+            margin-right: 0.75rem;
+            font-size: 1.1rem;
+        }
+
+        .sidebar-text {
+            font-weight: 500;
+        }
+
+        /* Touch device support */
+        @media (hover: none) and (pointer: coarse) {
+            .sidebar-trigger {
+                width: 16px;
+            }
+            
+            .sidebar-trigger:active + .sidebar,
+            .sidebar:focus-within {
+                left: 0;
+            }
+        }
+
+        /* Main content adjustment */
+        .main-content-wrapper {
+            transition: margin-left 0.3s cubic-bezier(.68,-0.55,.27,1.55);
+        }
+    </style>
 </head>
 <body class="min-h-screen font-sans text-text-primary" style="background-color: #001a4d;">
+    <!-- Sidebar Trigger -->
+    <div class="sidebar-trigger"></div>
+    
+    <!-- Sidebar -->
+    <nav class="sidebar">
+        <div class="sidebar-content">
+            <div class="sidebar-header">
+                <div class="flex items-center space-x-3 mb-8">
+                    <div class="w-8 h-8 bg-white/20 rounded-lg flex items-center justify-center">
+                        <span class="text-white font-bold">📁</span>
+                    </div>
+                    <span class="text-white font-semibold text-lg">Menü</span>
+                </div>
+            </div>
+            <div class="sidebar-menu">
+                <a href="#upload" class="sidebar-item">
+                    <span class="sidebar-icon">📤</span>
+                    <span class="sidebar-text">Upload</span>
+                </a>
+                <a href="#pages" class="sidebar-item">
+                    <span class="sidebar-icon">📄</span>
+                    <span class="sidebar-text">Seiten</span>
+                </a>
+                <a href="#palette-lab" class="sidebar-item">
+                    <span class="sidebar-icon">🎯</span>
+                    <span class="sidebar-text">Palette Lab</span>
+                </a>
+                <a href="#ui-def" class="sidebar-item">
+                    <span class="sidebar-icon">🎨</span>
+                    <span class="sidebar-text">UI Definition</span>
+                </a>
+            </div>
+        </div>
+    </nav>
+    
     <div class="max-w-6xl mx-auto px-5 py-8">
         <!-- Modern Navigation Header -->
         <nav class="flex justify-between items-center mb-8 bg-white/10 backdrop-blur-lg rounded-2xl px-6 py-4 border border-white/20">

--- a/script.js
+++ b/script.js
@@ -56,6 +56,9 @@ class HTMLPageManager {
             });
         }
 
+        // Sidebar functionality
+        this.initializeSidebar();
+
         // Keyboard events
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
@@ -272,6 +275,74 @@ class HTMLPageManager {
             localStorage.setItem('htmlPageManager_pages', JSON.stringify(this.pages));
         } catch (error) {
             console.error('Fehler beim Speichern der Seiten:', error);
+        }
+    }
+
+    initializeSidebar() {
+        const sidebarItems = document.querySelectorAll('.sidebar-item');
+        
+        sidebarItems.forEach(item => {
+            item.addEventListener('click', (e) => {
+                e.preventDefault();
+                const href = item.getAttribute('href');
+                
+                // Handle navigation based on href
+                switch(href) {
+                    case '#upload':
+                        this.scrollToSection('uploadArea');
+                        break;
+                    case '#pages':
+                        this.scrollToSection('pagesGrid');
+                        break;
+                    case '#palette-lab':
+                        window.location.href = 'palette-lab.html';
+                        break;
+                    case '#ui-def':
+                        window.location.href = 'ui-definition.html';
+                        break;
+                }
+            });
+        });
+
+        // Touch device support
+        if ('ontouchstart' in window) {
+            const trigger = document.querySelector('.sidebar-trigger');
+            let touchStartY = 0;
+            let sidebarVisible = false;
+
+            trigger.addEventListener('touchstart', (e) => {
+                touchStartY = e.touches[0].clientY;
+                sidebarVisible = !sidebarVisible;
+                this.toggleSidebar(sidebarVisible);
+            });
+
+            // Hide sidebar when touching outside
+            document.addEventListener('touchstart', (e) => {
+                const sidebar = document.querySelector('.sidebar');
+                if (sidebarVisible && !sidebar.contains(e.target) && !trigger.contains(e.target)) {
+                    sidebarVisible = false;
+                    this.toggleSidebar(false);
+                }
+            });
+        }
+    }
+
+    scrollToSection(elementId) {
+        const element = document.getElementById(elementId);
+        if (element) {
+            element.scrollIntoView({ 
+                behavior: 'smooth', 
+                block: 'start' 
+            });
+        }
+    }
+
+    toggleSidebar(show) {
+        const sidebar = document.querySelector('.sidebar');
+        if (show) {
+            sidebar.style.left = '0px';
+        } else {
+            sidebar.style.left = '-240px';
         }
     }
 }


### PR DESCRIPTION
Implements collapsible sidebar functionality as requested in issue #12

## Features
- Thin trigger bar (8px) remains visible on left edge
- Smooth hover animations with cubic-bezier transitions
- Navigation menu with Upload, Seiten, Palette Lab, UI Definition
- Touch device support with tap-to-toggle
- Glass-morphism design matching app aesthetic
- Smooth scrolling to page sections

Fixes #12

Generated with [Claude Code](https://claude.ai/code)