### PR TITLE
fix: Demo-Abdunklung im Palette Lab entfernt

### DIFF
--- a/palette-lab.html
+++ b/palette-lab.html
@@ -122,14 +122,14 @@
             left: 0;
         }
 
-        /* Overlay for closing sidebar */
+        /* Overlay for closing sidebar - transparent to prevent demo darkening */
         .palette-editor-overlay {
             position: fixed;
             top: 0;
             left: 0;
             width: 100vw;
             height: 100vh;
-            background: rgba(0, 0, 0, 0.2);
+            background: transparent;
             z-index: 1100;
             opacity: 0;
             pointer-events: none;


### PR DESCRIPTION
Fixes #26

Entfernt die Abdunklung der Demo-Seite wenn der Palette Editor geöffnet wird

**Changes:**
- palette-editor-overlay background von `rgba(0,0,0,0.2)` auf `transparent` geändert
- Demo-Seite wird nun nicht mehr abgedunkelt wenn Palette Editor geöffnet ist
- Overlay-Funktionalität bleibt bestehen für Click-to-Close

Generated with [Claude Code](https://claude.ai/code)