### PR TITLE
feat: Add Farbtafeln (color tiles) to Palette Editor Sidebar

### DIFF
--- a/palette-lab.html
+++ b/palette-lab.html
@@ -408,8 +408,23 @@ const colors = {
                 <div class="text-xs text-gray-500 mt-1">Änderungen werden sofort in der Demo angezeigt</div>
             </div>
 
+            <!-- Color Tiles Display -->
+            <div class="p-4 border-b border-gray-100">
+                <h4 class="text-sm font-semibold text-gray-700 mb-3 flex items-center">
+                    <span class="mr-2">🎨</span>
+                    Farbtafeln
+                </h4>
+                <div id="colorTiles" class="space-y-3">
+                    <!-- Color tiles will be rendered here -->
+                </div>
+            </div>
+
             <!-- Color Controls -->
             <div class="flex-1 p-4 space-y-4">
+                <h4 class="text-sm font-semibold text-gray-700 mb-3 flex items-center">
+                    <span class="mr-2">⚙️</span>
+                    Farben bearbeiten
+                </h4>
                 <div id="editColorInputs" class="space-y-3"></div>
             </div>
 

--- a/palette-lab.js
+++ b/palette-lab.js
@@ -1154,6 +1154,7 @@ class PaletteLab {
 
         // Update sidebar content
         document.getElementById('editPaletteName').textContent = name;
+        this.generateColorTiles(palette);
         this.generateEditColorInputs(palette);
         
         // Show sidebar
@@ -1180,6 +1181,51 @@ class PaletteLab {
         }
         
         this.currentEditPalette = null;
+    }
+
+    generateColorTiles(palette) {
+        const container = document.getElementById('colorTiles');
+        const primaryColors = [
+            { key: 'primary', label: 'Primary' },
+            { key: 'primaryLight', label: 'Primary Light' },
+            { key: 'primaryDark', label: 'Primary Dark' },
+            { key: 'secondary', label: 'Secondary' },
+            { key: 'secondaryLight', label: 'Secondary Light' },
+            { key: 'secondaryDark', label: 'Secondary Dark' },
+            { key: 'accent', label: 'Accent' }
+        ];
+
+        container.innerHTML = '';
+
+        primaryColors.forEach(({ key, label }) => {
+            const colorValue = palette[key] || '#000000';
+            const tile = document.createElement('div');
+            tile.className = 'flex flex-col space-y-1';
+            tile.innerHTML = `
+                <div class="text-xs font-medium text-gray-600">${label}</div>
+                <div class="h-8 rounded-md border border-gray-200 shadow-sm" style="background-color: ${colorValue};" title="${label}: ${colorValue}" data-color-tile="${key}"></div>
+                <div class="text-xs font-mono text-gray-700 text-center" data-color-code="${key}">${colorValue}</div>
+            `;
+            container.appendChild(tile);
+        });
+    }
+
+    updateColorTiles(palette) {
+        const primaryColors = ['primary', 'primaryLight', 'primaryDark', 'secondary', 'secondaryLight', 'secondaryDark', 'accent'];
+        
+        primaryColors.forEach(key => {
+            const colorValue = palette[key] || '#000000';
+            const tileElement = document.querySelector(`[data-color-tile="${key}"]`);
+            const codeElement = document.querySelector(`[data-color-code="${key}"]`);
+            
+            if (tileElement) {
+                tileElement.style.backgroundColor = colorValue;
+                tileElement.title = `${key}: ${colorValue}`;
+            }
+            if (codeElement) {
+                codeElement.textContent = colorValue;
+            }
+        });
     }
 
     generateEditColorInputs(palette) {
@@ -1272,6 +1318,9 @@ class PaletteLab {
 
         // Apply temporary preview to document
         this.applyPaletteToDocument(updatedPalette);
+        
+        // Update color tiles to show current values
+        this.updateColorTiles(updatedPalette);
         
         // Also apply to the current active frame if this is the active palette
         if (!this.compareMode && this.currentPaletteA === this.currentEditPalette) {


### PR DESCRIPTION
Fixes #26

Adds color tiles display section to the Palette Editor Sidebar with hex codes below each color tile, matching the reference image requirements.

**Changes:**
- Add color tiles display section above color editing controls
- Show primary colors as visual tiles with labels
- Display hex codes below each color tile
- Live update color tiles when colors are changed during editing
- Includes Primary, Primary Light/Dark, Secondary Light/Dark, Accent colors

**Technical Implementation:**
- `generateColorTiles()` function creates visual color tiles
- `updateColorTiles()` function provides live updates
- Integration with existing `showPaletteEditor()` and `previewPaletteChanges()`

🤖 Generated with [Claude Code](https://claude.ai/code)