### PR TITLE
Remove color picker modal, implement inline sidebar color picker

### DIFF
--- a/palette-lab.html
+++ b/palette-lab.html
@@ -419,6 +419,31 @@ const colors = {
                 </div>
             </div>
 
+            <!-- Inline Color Picker -->
+            <div id="inlineColorPicker" class="hidden p-4 border-b border-gray-100 bg-gradient-to-r from-primary/5 to-secondary/5">
+                <h4 class="text-sm font-semibold text-gray-700 mb-3 flex items-center">
+                    <span class="mr-2">🎨</span>
+                    <span id="inlineColorPickerTitle">Farbe bearbeiten</span>
+                </h4>
+                <div class="space-y-3">
+                    <div class="flex items-center space-x-3">
+                        <input type="color" id="inlineColorPickerInput" class="w-12 h-12 rounded-lg border-2 border-gray-300 cursor-pointer">
+                        <div class="flex-1">
+                            <input type="text" id="inlineColorTextInput" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary font-mono text-sm" placeholder="#000000">
+                            <div class="text-xs text-gray-500 mt-1">Hex-Code oder CSS-Farbe</div>
+                        </div>
+                    </div>
+                    <div class="flex space-x-2">
+                        <button id="confirmInlineColorPicker" class="flex-1 bg-primary text-white py-2 px-3 rounded-lg hover:bg-primary-dark transition-all text-sm font-medium">
+                            Übernehmen
+                        </button>
+                        <button id="cancelInlineColorPicker" class="px-3 py-2 text-gray-600 hover:text-gray-800 transition-all text-sm">
+                            Abbrechen
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             <!-- Instructions -->
             <div class="flex-1 p-4">
                 <h4 class="text-sm font-semibold text-gray-700 mb-3 flex items-center">
@@ -446,29 +471,6 @@ const colors = {
         </div>
     </div>
 
-    <!-- Color Picker Modal -->
-    <div id="colorPickerModal" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 hidden flex items-center justify-center">
-        <div class="bg-white rounded-xl p-6 max-w-md w-full mx-4">
-            <h3 class="text-lg font-semibold mb-4 text-text-primary flex items-center">
-                <span class="mr-2">🎨</span>
-                <span id="colorPickerTitle">Farbe bearbeiten</span>
-            </h3>
-            <div class="mb-4">
-                <label class="block text-sm font-medium mb-2" id="colorPickerLabel">Farbe auswählen:</label>
-                <div class="flex items-center space-x-4">
-                    <input type="color" id="colorPickerInput" class="w-16 h-16 rounded-lg border-2 border-gray-300 cursor-pointer">
-                    <div class="flex-1">
-                        <input type="text" id="colorTextInput" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary font-mono" placeholder="#000000">
-                        <div class="text-xs text-gray-500 mt-1">Hex-Code oder CSS-Farbe</div>
-                    </div>
-                </div>
-            </div>
-            <div class="flex justify-end space-x-2">
-                <button id="cancelColorPicker" class="px-4 py-2 text-gray-600 hover:text-gray-800">Abbrechen</button>
-                <button id="confirmColorPicker" class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark">Übernehmen</button>
-            </div>
-        </div>
-    </div>
 
     <!-- Error Modal -->
     <div id="errorModal" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 hidden flex items-center justify-center">

--- a/palette-lab.js
+++ b/palette-lab.js
@@ -169,13 +169,13 @@ class PaletteLab {
             this.hideEditSidebar();
         });
 
-        // Color Picker Modal events
-        document.getElementById('cancelColorPicker').addEventListener('click', () => {
-            this.hideColorPickerModal();
+        // Inline Color Picker events
+        document.getElementById('cancelInlineColorPicker').addEventListener('click', () => {
+            this.hideInlineColorPicker();
         });
 
-        document.getElementById('confirmColorPicker').addEventListener('click', () => {
-            this.handleColorPickerConfirm();
+        document.getElementById('confirmInlineColorPicker').addEventListener('click', () => {
+            this.handleInlineColorPickerConfirm();
         });
 
         // Keyboard events
@@ -186,7 +186,7 @@ class PaletteLab {
                 this.hideJsonImportModal();
                 this.hideCreatePaletteModal();
                 this.hideEditModal();
-                this.hideColorPickerModal();
+                this.hideInlineColorPicker();
             }
         });
     }
@@ -1242,7 +1242,7 @@ class PaletteLab {
             const colorTileDiv = tile.querySelector(`[data-color-tile="${key}"]`);
             colorTileDiv.addEventListener('click', (e) => {
                 e.stopPropagation();
-                this.showColorPickerModal(key, label, colorValue);
+                this.showInlineColorPicker(key, label, colorValue);
             });
             
             container.appendChild(tile);
@@ -1366,48 +1366,50 @@ class PaletteLab {
         alert('Palette erfolgreich aktualisiert!');
     }
 
-    showColorPickerModal(colorKey, colorLabel, currentColor) {
+    showInlineColorPicker(colorKey, colorLabel, currentColor) {
         this.currentColorKey = colorKey;
         
-        document.getElementById('colorPickerTitle').textContent = `${colorLabel} bearbeiten`;
-        document.getElementById('colorPickerLabel').textContent = `${colorLabel} Farbe:`;
-        document.getElementById('colorPickerInput').value = currentColor;
-        document.getElementById('colorTextInput').value = currentColor;
+        document.getElementById('inlineColorPickerTitle').textContent = `${colorLabel} bearbeiten`;
+        document.getElementById('inlineColorPickerInput').value = currentColor;
+        document.getElementById('inlineColorTextInput').value = currentColor;
         
-        document.getElementById('colorPickerModal').classList.remove('hidden');
-        document.getElementById('colorPickerInput').focus();
+        document.getElementById('inlineColorPicker').classList.remove('hidden');
+        document.getElementById('inlineColorPickerInput').focus();
         
         // Sync color picker and text input
-        const colorInput = document.getElementById('colorPickerInput');
-        const textInput = document.getElementById('colorTextInput');
+        const colorInput = document.getElementById('inlineColorPickerInput');
+        const textInput = document.getElementById('inlineColorTextInput');
         
-        const syncInputs = () => {
-            colorInput.addEventListener('input', () => {
-                textInput.value = colorInput.value;
-            });
-            
-            textInput.addEventListener('input', () => {
-                if (this.isValidColor(textInput.value)) {
-                    colorInput.value = textInput.value;
-                }
-            });
-        };
+        // Remove any existing listeners to prevent duplicates
+        const newColorInput = colorInput.cloneNode(true);
+        const newTextInput = textInput.cloneNode(true);
+        colorInput.parentNode.replaceChild(newColorInput, colorInput);
+        textInput.parentNode.replaceChild(newTextInput, textInput);
         
-        syncInputs();
+        // Add new listeners
+        newColorInput.addEventListener('input', () => {
+            newTextInput.value = newColorInput.value;
+        });
+        
+        newTextInput.addEventListener('input', () => {
+            if (this.isValidColor(newTextInput.value)) {
+                newColorInput.value = newTextInput.value;
+            }
+        });
     }
 
-    hideColorPickerModal() {
-        document.getElementById('colorPickerModal').classList.add('hidden');
+    hideInlineColorPicker() {
+        document.getElementById('inlineColorPicker').classList.add('hidden');
         this.currentColorKey = null;
     }
 
-    handleColorPickerConfirm() {
+    handleInlineColorPickerConfirm() {
         if (!this.currentColorKey || !this.currentEditPalette) {
-            this.hideColorPickerModal();
+            this.hideInlineColorPicker();
             return;
         }
         
-        const newColor = document.getElementById('colorTextInput').value.trim();
+        const newColor = document.getElementById('inlineColorTextInput').value.trim();
         
         if (!this.isValidColor(newColor)) {
             this.showError('Ungültige Farbe', `Die eingegebene Farbe "${newColor}" ist nicht gültig.`);
@@ -1425,7 +1427,7 @@ class PaletteLab {
             this.previewPaletteChanges();
         }
         
-        this.hideColorPickerModal();
+        this.hideInlineColorPicker();
     }
 }
 


### PR DESCRIPTION
Removes the modal-based color picker and implements an inline color picker directly within the palette editor sidebar.

## Changes:
- Removed colorPickerModal HTML completely
- Added inline color picker within palette editor sidebar
- Updated all JavaScript functions from modal-based to inline
- Color picker now appears directly in sidebar when clicking color tiles
- Maintains live preview functionality and color synchronization

Fixes #33

Generated with [Claude Code](https://claude.ai/code)