### PR TITLE
feat: implement immediate popup color picker with undo functionality

### DIFF
--- a/palette-lab.html
+++ b/palette-lab.html
@@ -484,6 +484,34 @@ const colors = {
         </div>
     </div>
 
+    <!-- Popup Color Picker -->
+    <div id="popupColorPicker" class="hidden fixed z-50 bg-white border border-gray-300 rounded-lg shadow-xl p-4 min-w-[280px]">
+        <div class="flex items-center justify-between mb-3">
+            <h4 class="text-sm font-semibold text-gray-700 flex items-center">
+                <span class="mr-2">🎨</span>
+                <span id="popupColorPickerTitle">Farbe bearbeiten</span>
+            </h4>
+            <button id="popupColorPickerClose" class="text-gray-400 hover:text-gray-600 text-lg leading-none">&times;</button>
+        </div>
+        <div class="space-y-3">
+            <div class="flex items-center space-x-3">
+                <input type="color" id="popupColorPickerInput" class="w-12 h-12 rounded-lg border-2 border-gray-300 cursor-pointer">
+                <div class="flex-1">
+                    <input type="text" id="popupColorTextInput" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary font-mono text-sm" placeholder="#000000">
+                    <div class="text-xs text-gray-500 mt-1">Hex-Code oder CSS-Farbe</div>
+                </div>
+            </div>
+            <div class="flex space-x-2">
+                <button id="popupColorPickerUndo" class="px-3 py-2 text-gray-600 hover:text-gray-800 transition-all text-sm border border-gray-300 rounded-lg">
+                    Rückgängig
+                </button>
+                <button id="popupColorPickerClose2" class="flex-1 text-gray-600 hover:text-gray-800 transition-all text-sm">
+                    Schließen
+                </button>
+            </div>
+        </div>
+    </div>
+
     <script src="palette-lab.js"></script>
 </body>
 </html>

--- a/palette-lab.html
+++ b/palette-lab.html
@@ -452,15 +452,19 @@ const colors = {
                 </h4>
                 <div class="text-sm text-gray-600 space-y-2">
                     <p><strong>Direkte Bearbeitung:</strong></p>
-                    <p>• <strong>Ein Klick auf eine Farbkachel</strong> öffnet den Farbpicker</p>
-                    <p>• Alle Palettenfarben sind bearbeitbar</p>
+                    <p>• <strong>Ein Klick auf eine Farbkachel</strong> öffnet den nativen Farbpicker</p>
+                    <p>• Sofortiges Ändern von Farben ohne weitere Schritte</p>
                     <p>• Live-Vorschau in der Demo</p>
+                    <p>• <strong>Rückgängig-Button</strong> stellt alle Originalfarben wieder her</p>
                     <p>• Speichern am Ende nicht vergessen</p>
                 </div>
             </div>
 
             <!-- Footer -->
             <div class="p-4 border-t border-gray-200 bg-gray-50 space-y-2">
+                <button id="undoAllChanges" class="w-full bg-gray-500 text-white py-2 px-4 rounded-lg hover:bg-gray-600 transition-all font-medium">
+                    Alle Änderungen rückgängig
+                </button>
                 <button id="confirmEditPalette" class="w-full bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-all font-medium">
                     Änderungen speichern
                 </button>


### PR DESCRIPTION
This PR implements the requested immediate popup color picker functionality for issue #35.

**Changes:**
- Add popup color picker that appears directly at mouse click position
- Implement immediate color changes with live preview updates
- Add undo functionality to restore original colors
- Position popup within viewport boundaries
- Maintain demo visibility without darkening
- Replace inline sidebar color picker with popup interface

**Features:**
- Immediate appearance on click (no intermediate steps)
- Positioned at exact mouse click location
- Live color updates with immediate preview
- Undo functionality for color changes
- Demo page remains visible (no darkening)
- German UI language maintained

Resolves #35

Generated with [Claude Code](https://claude.ai/code)