### PR TITLE
fix: resolve native color picker not appearing on color tile clicks

### DIFF
--- a/palette-lab.js
+++ b/palette-lab.js
@@ -1244,7 +1244,7 @@ class PaletteLab {
                 <div class="text-xs font-medium text-gray-600">${label}</div>
                 <div class="h-8 rounded-md border border-gray-200 shadow-sm cursor-pointer hover:shadow-md transition-shadow" style="background-color: ${colorValue};" title="${label}: ${colorValue} - Klicken zum Bearbeiten" data-color-tile="${key}"></div>
                 <div class="text-xs font-mono text-gray-700 text-center" data-color-code="${key}">${colorValue}</div>
-                <input type="color" id="hidden-color-picker-${key}" style="position: absolute; left: -9999px; opacity: 0;" value="${colorValue}">
+                <input type="color" id="hidden-color-picker-${key}" style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;" value="${colorValue}">
             `;
             
             // Add click event listener to the color tile
@@ -1258,7 +1258,10 @@ class PaletteLab {
                 e.stopPropagation();
                 this.currentColorKey = key;
                 this.originalColor = colorValue;
-                hiddenColorPicker.click();
+                // Force trigger the color picker
+                setTimeout(() => {
+                    hiddenColorPicker.click();
+                }, 0);
             });
             
             // Handle color change from native color picker


### PR DESCRIPTION
This PR fixes the issue where clicking on color tiles didn't open the HTML5 color picker.

**Root cause:** Hidden color picker elements used `opacity: 0` styling, which modern browsers block for programmatic clicks as a security measure.

**Solution:**
- Replaced `opacity: 0` with minimal dimensions and overflow hidden
- Added setTimeout wrapper for better click event handling
- Maintains invisibility while allowing browser interactions

**Testing:** Color picker now opens immediately when clicking color tiles in the palette editor.

Resolves issue reported in #36

Generated with [Claude Code](https://claude.ai/code)